### PR TITLE
Create directory for gobuster.

### DIFF
--- a/modules/subdomain.py
+++ b/modules/subdomain.py
@@ -7,6 +7,7 @@ class SubdomainScanning(object):
 	def __init__(self, options):
 		utils.print_banner("Scanning Subdomain")
 		utils.make_directory(options['env']['WORKSPACE'] + '/subdomain')
+		utils.make_directory(options['env']['WORKSPACE'] + '/directory')
 		self.options = options
 		self.initial()
 


### PR DESCRIPTION
The gobuster command was failing because the 'directory' output path was not being created. It seems to get created when running -m dir, but not when running -m subdomain.