### PR TITLE
Removed unnecessary findomain flag.

### DIFF
--- a/lib/workflow/direct.py
+++ b/lib/workflow/direct.py
@@ -30,7 +30,7 @@ class SubdomainScanning:
             },
             {
                 "banner": "findomain",
-                "cmd": "$PLUGINS_PATH/findomain -t $TARGET -i | tee $WORKSPACE/subdomain/$OUTPUT-findomain.txt",
+                "cmd": "$PLUGINS_PATH/findomain -t $TARGET | tee $WORKSPACE/subdomain/$OUTPUT-findomain.txt",
                 "output_path": "$WORKSPACE/subdomain/$OUTPUT-findomain.txt",
                 "std_path": "$WORKSPACE/subdomain/std-$OUTPUT-findomain.std",
                 "post_run": "clean_findomain",

--- a/lib/workflow/general.py
+++ b/lib/workflow/general.py
@@ -51,7 +51,7 @@ class SubdomainScanning:
             },
             {
                 "banner": "findomain",
-                "cmd": "$PLUGINS_PATH/findomain -t $TARGET -i | tee $WORKSPACE/subdomain/$OUTPUT-findomain.txt",
+                "cmd": "$PLUGINS_PATH/findomain -t $TARGET | tee $WORKSPACE/subdomain/$OUTPUT-findomain.txt",
                 "output_path": "$WORKSPACE/subdomain/$OUTPUT-findomain.txt",
                 "std_path": "$WORKSPACE/subdomain/std-$OUTPUT-findomain.std",
                 "post_run": "clean_findomain",


### PR DESCRIPTION
Simply removed the old `-i` flag from findomain. The findomain command execution breaks with this flag.