### PR TITLE
Install truffleHog with pip3 to be able to solve its GitPython dependancy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -230,7 +230,7 @@ chmod +x $PLUGINS_PATH/findomain
 ##
 
 install_banner "truffleHog"
-pip install truffleHog
+pip3 install truffleHog
 
 cd $PLUGINS_PATH
 


### PR DESCRIPTION
When truflleHog is installed with pip, GitPython complains:

```Collecting GitPython==3.0.6 (from truffleHog)
  Could not find a version that satisfies the requirement GitPython==3.0.6 (from truffleHog) (from versions: 0.1.7, 0.2.0b1, 0.3.0b1, 0.3.0b2, 0.3.1b2, 0.3.2rc1, 0.3.2, 0.3.2.1, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 1.0.0, 1.0.1, 1.0.2, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8, 2.0.9.dev0, 2.0.9.dev1, 2.0.9, 2.1.0, 2.1.1, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.1.7, 2.1.8, 2.1.9, 2.1.10, 2.1.11, 2.1.13, 2.1.14, 2.1.15)
No matching distribution found for GitPython==3.0.6 (from truffleHog)
```

It works as a charm when pip3 is used.