### PR TITLE
Fixing the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
     git clone --depth 1 https://github.com/j3ssie/Osmedeus -b $OSMEDEUS_VERSION . && \
     ./install.sh && \
     go get -u github.com/tomnomnom/unfurl && \
-    apt-get clean && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 EXPOSE 8000
 CMD ["./osmedeus.py"]


### PR DESCRIPTION
Difference between apt-get clean and apt-get autoremove
They two commands are not same and have absolutely different functions. Apt-get clean or apt-get autoclean removes the retrieved packages from the local cache only while the apt-get autoremove removes the unneeded packages that were once installed as a dependency.