### PR TITLE
Fix "version" attribute name

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -44,7 +44,7 @@ type StatData struct {
     CPU     string `json:"cpu"`
     Mem     string `json:"mem"`
     Name    string `json:"name"`
-    Version string `json:"verion"`
+    Version string `json:"version"`
 }
 
 // PrintStat print status


### PR DESCRIPTION
Hi @j3ssie. When you run the command `osmedeus version --json` to get the program version in JSON format, the `version` attribute is mislabeled and it says `verion` instead:
```
{"cpu":"9.181141439205959","mem":"49.474370596173564","name":"2b7ac749ef29","verion":"osmedeus beta v4.0.1 by @j3ssiejjj"}
```
This is a very simple patch to fix that attribute name.