### PR TITLE
Replace t.WarnF with t.Error

### DIFF
--- a/execution/git_test.go
+++ b/execution/git_test.go
@@ -1,25 +1,25 @@
 package execution
 
 import (
-    "fmt"
-    "testing"
+	"fmt"
+	"testing"
 
-    "github.com/j3ssie/osmedeus/libs"
-    "github.com/j3ssie/osmedeus/utils"
+	"github.com/j3ssie/osmedeus/libs"
+	"github.com/j3ssie/osmedeus/utils"
 )
 
 func TestDiffCompare(t *testing.T) {
-    var options libs.Options
-    options.Debug = true
-    DiffCompare("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/final-duckduckgo.com.txt", "/Users/j3ssie/.osmedeus/storages/summary/duckduckgo.com/subdomain-duckduckgo.com.txt", "/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt", options)
-    // DiffCompare(options)
-    // fmt.Println(result)
+	var options libs.Options
+	options.Debug = true
+	DiffCompare("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/final-duckduckgo.com.txt", "/Users/j3ssie/.osmedeus/storages/summary/duckduckgo.com/subdomain-duckduckgo.com.txt", "/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt", options)
+	// DiffCompare(options)
+	// fmt.Println(result)
 
-    data := utils.GetFileContent("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt")
-    fmt.Println(data)
+	data := utils.GetFileContent("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt")
+	fmt.Println(data)
 
-    if !utils.FileExists("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt") {
-        t.WarnF("Error DiffCompare")
-    }
+	if !utils.FileExists("/Users/j3ssie/.osmedeus/workspaces/duckduckgo.com/subdomain/diff-duckduckgo.com-2019-12-28_3:20:9.txt") {
+		t.Error("Error DiffCompare")
+	}
 
 }


### PR DESCRIPTION
I replaced t.WarnF with t.Error because testing package doesn't have WarnF().