### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
+	"io"
+	"net/http"
+	"path/filepath"
+
 	"github.com/fatih/color"
 	"github.com/j3ssie/osmedeus/core"
 	"github.com/j3ssie/osmedeus/utils"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
 )
 
 func init() {
@@ -121,7 +122,7 @@ func getPublicIP() string {
 	}
 	defer req.Body.Close()
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return "127.0.0.1"
 	}

--- a/core/parse.go
+++ b/core/parse.go
@@ -3,11 +3,6 @@ package core
 import (
 	"bytes"
 	"fmt"
-	"github.com/Jeffail/gabs/v2"
-	"github.com/fatih/color"
-	"github.com/spf13/cast"
-	"golang.org/x/net/publicsuffix"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -16,9 +11,13 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/Jeffail/gabs/v2"
 	"github.com/Shopify/yaml"
+	"github.com/fatih/color"
 	"github.com/j3ssie/osmedeus/libs"
 	"github.com/j3ssie/osmedeus/utils"
+	"github.com/spf13/cast"
+	"golang.org/x/net/publicsuffix"
 )
 
 // ResolveData resolve template from signature file
@@ -58,7 +57,7 @@ func AltResolveVariable(format string, data map[string]string) string {
 func ParseFlow(flowFile string) (libs.Flow, error) {
 	utils.DebugF("Parsing workflow at: %v", color.HiGreenString(flowFile))
 	var flow libs.Flow
-	yamlFile, err := ioutil.ReadFile(flowFile)
+	yamlFile, err := os.ReadFile(flowFile)
 	if err != nil {
 		utils.ErrorF("YAML parsing err: %v -- #%v ", flowFile, err)
 		return flow, err
@@ -81,7 +80,7 @@ func ParseModules(moduleFile string) (libs.Module, error) {
 
 	var module libs.Module
 
-	yamlFile, err := ioutil.ReadFile(moduleFile)
+	yamlFile, err := os.ReadFile(moduleFile)
 	if err != nil {
 		utils.ErrorF("YAML parsing err: %v -- #%v ", moduleFile, err)
 		return module, err

--- a/core/report.go
+++ b/core/report.go
@@ -2,21 +2,21 @@ package core
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/Jeffail/gabs/v2"
 	"github.com/fatih/color"
 	"github.com/j3ssie/osmedeus/libs"
 	"github.com/j3ssie/osmedeus/utils"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cast"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 func ListWorkspaces(options libs.Options) (content [][]string) {
-	workspaces, err := ioutil.ReadDir(utils.NormalizePath(options.Env.WorkspacesFolder))
+	workspaces, err := os.ReadDir(utils.NormalizePath(options.Env.WorkspacesFolder))
 	if err != nil {
 		utils.ErrorF("Error reading workspaces folder: %s", err)
 		return content
@@ -76,7 +76,7 @@ func ListWorkspaces(options libs.Options) (content [][]string) {
 }
 
 func ListSingleWorkspace(options libs.Options, target string) (content [][]string) {
-	workspaces, err := ioutil.ReadDir(utils.NormalizePath(options.Env.WorkspacesFolder))
+	workspaces, err := os.ReadDir(utils.NormalizePath(options.Env.WorkspacesFolder))
 	if err != nil {
 		utils.ErrorF("Error reading workspaces folder: %s", err)
 		return content

--- a/core/step.go
+++ b/core/step.go
@@ -3,13 +3,14 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/fatih/color"
 	"github.com/j3ssie/osmedeus/libs"
 	"github.com/j3ssie/osmedeus/utils"
 	"github.com/thoas/go-funk"
-	"strings"
-	"sync"
-	"time"
 )
 
 func (r *Runner) RunModulesWithTimeout(timeoutRaw string, module libs.Module, options libs.Options) {
@@ -69,7 +70,7 @@ func ResolveReports(module libs.Module, params map[string]string) libs.Module {
 	return module
 }
 
-//  print all report
+// print all report
 func printReports(module libs.Module) {
 	var files []string
 	files = append(files, module.Report.Final...)

--- a/database/connect.go
+++ b/database/connect.go
@@ -2,14 +2,14 @@ package database
 
 import (
 	"fmt"
-	"github.com/j3ssie/osmedeus/libs"
-	"github.com/j3ssie/osmedeus/utils"
-	"gorm.io/gorm/logger"
-	"io/ioutil"
+	"io"
 	"log"
 	"time"
 
+	"github.com/j3ssie/osmedeus/libs"
+	"github.com/j3ssie/osmedeus/utils"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 
 	// load driver
 	"gorm.io/driver/mysql"
@@ -22,7 +22,7 @@ var DB *gorm.DB
 // InitDB connect to db
 func InitDB(options libs.Options) (*gorm.DB, error) {
 	newLogger := logger.New(
-		log.New(ioutil.Discard, "\r\n", log.LstdFlags), // io writer
+		log.New(io.Discard, "\r\n", log.LstdFlags), // io writer
 		logger.Config{
 			SlowThreshold:             time.Second, // Slow SQL threshold
 			LogLevel:                  logger.Info, // Log level

--- a/distribute/ssh.go
+++ b/distribute/ssh.go
@@ -5,14 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/j3ssie/osmedeus/utils"
-
 	"golang.org/x/crypto/ssh"
 )
 
@@ -106,7 +104,7 @@ func DialWithKeyString(addr, user, keyContent string) (*Client, error) {
 
 // DialWithKey starts a client connection to the given SSH server with key authmethod.
 func DialWithKey(addr, user, keyfile string) (*Client, error) {
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := os.ReadFile(keyfile)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +127,7 @@ func DialWithKey(addr, user, keyfile string) (*Client, error) {
 
 // DialWithKeyWithPassphrase same as DialWithKey but with a passphrase to decrypt the private key
 func DialWithKeyWithPassphrase(addr, user, keyfile string, passphrase string) (*Client, error) {
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := os.ReadFile(keyfile)
 	if err != nil {
 		return nil, err
 	}

--- a/execution/request.go
+++ b/execution/request.go
@@ -5,9 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/j3ssie/osmedeus/libs"
-	"github.com/j3ssie/osmedeus/utils"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -15,6 +13,8 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/j3ssie/osmedeus/libs"
+	"github.com/j3ssie/osmedeus/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ func BuildClient(token string, retry int) *resty.Client {
 
 	// disable log when retry
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 
 	client := resty.New()
 	client.SetLogger(logger)

--- a/execution/scripts.go
+++ b/execution/scripts.go
@@ -5,9 +5,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
-	"github.com/j3ssie/osmedeus/libs"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -16,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/j3ssie/osmedeus/libs"
 	"github.com/j3ssie/osmedeus/utils"
 )
 
@@ -119,8 +118,8 @@ func Copy(src string, dest string) {
 	if !utils.FileExists(src) || utils.FileLength(src) <= 0 {
 		return
 	}
-	input, _ := ioutil.ReadFile(src)
-	ioutil.WriteFile(dest, input, 0644)
+	input, _ := os.ReadFile(src)
+	os.WriteFile(dest, input, 0644)
 }
 
 // Sort sort content of a file

--- a/provider/parser.go
+++ b/provider/parser.go
@@ -1,9 +1,10 @@
 package provider
 
 import (
+	"os"
+
 	"github.com/Shopify/yaml"
 	"github.com/j3ssie/osmedeus/utils"
-	"io/ioutil"
 )
 
 // ConfigProviders cloud config file
@@ -56,7 +57,7 @@ func ParseProvider(cloudFile string) (ConfigProviders, error) {
 	var clouds ConfigProviders
 	cloudFile = utils.NormalizePath(cloudFile)
 
-	yamlFile, err := ioutil.ReadFile(cloudFile)
+	yamlFile, err := os.ReadFile(cloudFile)
 	if err != nil {
 		utils.ErrorF("YAML parsing err #%v ", err)
 		return clouds, err

--- a/provider/provider_digitalocean.go
+++ b/provider/provider_digitalocean.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -219,7 +219,7 @@ func (p *Provider) CreateInstanceDO(name string) (dropletId int, err error) {
 	instance, res, err := client.Droplets.Create(ctx, createRequest)
 	if err != nil {
 		utils.ErrorF("error create digital ocean instance -- %v", err)
-		content, ok := ioutil.ReadAll(res.Body)
+		content, ok := io.ReadAll(res.Body)
 		if ok == nil {
 			fmt.Println(string(content))
 		}

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/url"
 	"os"
@@ -148,7 +147,7 @@ func GetFileContent(filename string) string {
 		return result
 	}
 	defer file.Close()
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		return result
 	}
@@ -301,10 +300,10 @@ func FileLength(filename string) int {
 // DirLength count len of file
 func DirLength(dir string) int {
 	dir = NormalizePath(dir)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		dir = dir + "/"
-		files, err = ioutil.ReadDir(dir)
+		files, err = os.ReadDir(dir)
 		if err == nil {
 			return len(files)
 		}
@@ -320,8 +319,8 @@ func Copy(src string, dest string) {
 	if !FileExists(src) || FileLength(src) <= 0 {
 		return
 	}
-	input, _ := ioutil.ReadFile(src)
-	ioutil.WriteFile(dest, input, 0644)
+	input, _ := os.ReadFile(src)
+	os.WriteFile(dest, input, 0644)
 }
 
 // GetTS get current timestamp and return a string
@@ -660,7 +659,7 @@ func FolderLength(dir string) int {
 	if FileExists(dir) {
 		dir = path.Dir(dir)
 	}
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return length
 	}
@@ -679,7 +678,7 @@ func ImageAsBase64(src string) string {
 
 	// Read entire JPG into byte slice.
 	reader := bufio.NewReader(f)
-	content, err := ioutil.ReadAll(reader)
+	content, err := io.ReadAll(reader)
 	if err != nil {
 		return ""
 	}

--- a/utils/log.go
+++ b/utils/log.go
@@ -2,16 +2,16 @@ package utils
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/j3ssie/osmedeus/libs"
 	"github.com/kyokomi/emoji"
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var logger = logrus.New()
@@ -24,7 +24,7 @@ func InitLog(options *libs.Options) {
 		if !FolderExists(logDir) {
 			os.MkdirAll(logDir, 0766)
 		}
-		tmpFile, err := ioutil.TempFile(logDir, "osmedeus-*.log")
+		tmpFile, err := os.CreateTemp(logDir, "osmedeus-*.log")
 		if err == nil {
 			options.LogFile = tmpFile.Name()
 		}
@@ -60,7 +60,7 @@ func InitLog(options *libs.Options) {
 	} else if options.Verbose == true {
 		logger.SetLevel(logrus.ErrorLevel)
 	} else if options.Quite == true {
-		logger.SetOutput(ioutil.Discard)
+		logger.SetOutput(io.Discard)
 	}
 }
 

--- a/utils/request.go
+++ b/utils/request.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"github.com/j3ssie/osmedeus/libs"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/j3ssie/osmedeus/libs"
 )
 
 var DefaultClient *http.Client
@@ -61,7 +62,7 @@ func SendGET(cred string, url string) (res Response) {
 	}
 
 	defer resp.Body.Close()
-	resbody, err := ioutil.ReadAll(resp.Body)
+	resbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return res
 	}
@@ -85,7 +86,7 @@ func SendPOST(cred string, url string, body string) (res Response) {
 		return res
 	}
 	defer resp.Body.Close()
-	resbody, err := ioutil.ReadAll(resp.Body)
+	resbody, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return res
@@ -110,7 +111,7 @@ func SendPUT(cred string, url string, body string) (res Response) {
 		return res
 	}
 	defer resp.Body.Close()
-	resbody, err := ioutil.ReadAll(resp.Body)
+	resbody, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return res


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir