### PR TITLE
print stderr and script errors to console

### DIFF
--- a/core/runtime.go
+++ b/core/runtime.go
@@ -27,6 +27,8 @@ func (r *Runner) ExecScript(script string) string {
 		if nerr == nil {
 			return out
 		}
+	} else {
+		utils.ErrorF("Error running script: %s", err.Error())
 	}
 
 	return ""

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -414,12 +414,19 @@ func runCommandWithError(cmd string) (string, error) {
 
 	// output command output to std too
 	cmdReader, _ := realCmd.StdoutPipe()
+	errReader, _ := realCmd.StderrPipe()
 	scanner := bufio.NewScanner(cmdReader)
+	errScanner := bufio.NewScanner(errReader)
 	go func() {
 		for scanner.Scan() {
 			out := scanner.Text()
-			DebugF(out)
+			Debug(out)
 			output += out + "\n"
+		}
+	}()
+	go func() {
+		for errScanner.Scan() {
+			Error(errScanner.Text())
 		}
 	}()
 	if err := realCmd.Start(); err != nil {
@@ -454,6 +461,7 @@ func RunCommandWithErr(command string, timeoutRaw ...string) (string, error) {
 
 	select {
 	case <-c.Done():
+
 		return output, err
 	case <-time.After(time.Duration(timeout) * time.Second):
 		return out, fmt.Errorf("command got timeout")
@@ -472,12 +480,19 @@ func RunCommandSteamOutput(cmd string) (string, error) {
 
 	// output command output to std too
 	cmdReader, _ := realCmd.StdoutPipe()
+	errReader, _ := realCmd.StderrPipe()
 	scanner := bufio.NewScanner(cmdReader)
+	errScanner := bufio.NewScanner(errReader)
 	go func() {
 		for scanner.Scan() {
 			out := scanner.Text()
 			fmt.Println(out)
 			output += out
+		}
+	}()
+	go func() {
+		for errScanner.Scan() {
+			ErrorF(errScanner.Text())
 		}
 	}()
 	if err := realCmd.Start(); err != nil {
@@ -501,12 +516,19 @@ func RunOSCommand(cmd string) (string, error) {
 
 	// output command output to std too
 	cmdReader, _ := realCmd.StdoutPipe()
+	errReader, _ := realCmd.StderrPipe()
 	scanner := bufio.NewScanner(cmdReader)
+	errScanner := bufio.NewScanner(errReader)
 	go func() {
 		for scanner.Scan() {
 			out := scanner.Text()
-			DebugF(out)
+			Debug(out)
 			output += out
+		}
+	}()
+	go func() {
+		for errScanner.Scan() {
+			Error(errScanner.Text())
 		}
 	}()
 	if err := realCmd.Start(); err != nil {
@@ -528,10 +550,17 @@ func RunCommandWithoutOutput(cmd string) error {
 	DebugF("[Exec] %v", command)
 	realCmd := exec.Command(command[0], command[1:]...)
 	cmdReader, _ := realCmd.StdoutPipe()
+	errReader, _ := realCmd.StderrPipe()
 	scanner := bufio.NewScanner(cmdReader)
+	errScanner := bufio.NewScanner(errReader)
 	go func() {
 		for scanner.Scan() {
 			InforF(scanner.Text())
+		}
+	}()
+	go func() {
+		for errScanner.Scan() {
+			ErrorF(errScanner.Text())
 		}
 	}()
 	if err := realCmd.Start(); err != nil {

--- a/utils/log.go
+++ b/utils/log.go
@@ -101,9 +101,19 @@ func InforF(format string, args ...interface{}) {
 	logger.Info(fmt.Sprintf(format, args...))
 }
 
+// Infor print info message
+func Infor(args ...interface{}) {
+	logger.Info(args...)
+}
+
 // ErrorF print good message
 func ErrorF(format string, args ...interface{}) {
 	logger.Error(fmt.Sprintf(format, args...))
+}
+
+// Error print good message
+func Error(args ...interface{}) {
+	logger.Error(args...)
 }
 
 // WarnF print good message
@@ -111,14 +121,29 @@ func WarnF(format string, args ...interface{}) {
 	logger.Warning(fmt.Sprintf(format, args...))
 }
 
+// Warn print good message
+func Warn(args ...interface{}) {
+	logger.Warning(args...)
+}
+
 // TraceF print good message
 func TraceF(format string, args ...interface{}) {
 	logger.Trace(fmt.Sprintf(format, args...))
 }
 
+// Trace print good message
+func Trace(args ...interface{}) {
+	logger.Trace(args...)
+}
+
 // DebugF print debug message
 func DebugF(format string, args ...interface{}) {
 	logger.Debug(fmt.Sprintf(format, args...))
+}
+
+// Debug print debug message
+func Debug(args ...interface{}) {
+	logger.Debug(args...)
 }
 
 // Emojif print good message


### PR DESCRIPTION
I think this makes writing workflows a little bit easier, as stderr was previously just ignored and errors not printed. The same for printing script error messages.
Also using `Debug` instead of `DebugF` for output prevents accential interpreting format strings like `%s`  in command output