### PR TITLE
Fix confusing param display and added an alert when running module main steps

### DIFF
--- a/core/module.go
+++ b/core/module.go
@@ -43,6 +43,7 @@ func (r *Runner) RunModule(module libs.Module) {
 		r.RunScripts(module.PreRun)
 	}
 
+	utils.InforF("Running steps for module %v", color.CyanString(module.Name))
 	// main part
 	err := r.RunSteps(module.Steps)
 	if err != nil {

--- a/core/runner.go
+++ b/core/runner.go
@@ -320,9 +320,6 @@ func (r *Runner) ResolveRoutine() {
 	// print some info about the routine
 	var totalSteps, totalModules int
 	parameters := make(map[string]string)
-	for k, v := range r.Params {
-		parameters[k] = v
-	}
 
 	for _, routine := range r.Routines {
 		// loop through all modules to get the parameters
@@ -339,6 +336,10 @@ func (r *Runner) ResolveRoutine() {
 			totalSteps += len(module.Steps)
 			totalModules++
 		}
+	}
+
+	for k, v := range r.Params {
+		parameters[k] = v
 	}
 
 	var toggleFlags, skippingFlags, ThreadsFlags []string
@@ -369,11 +370,11 @@ func (r *Runner) ResolveRoutine() {
 	}
 
 	if len(toggleFlags) > 0 || len(skippingFlags) > 0 {
-		utils.InforF("🔘 Toggleable and Skippable Parameters that being use: %v, %v", strings.Join(toggleFlags, ", "), strings.Join(skippingFlags, ", "))
+		utils.InforF("🔘 Toggleable and Skippable Parameters being used: %v, %v", strings.Join(toggleFlags, ", "), strings.Join(skippingFlags, ", "))
 		if r.Opt.Verbose {
 			utils.InforF("🚀 Speed Control that being use: %v", strings.Join(ThreadsFlags, ", "))
 		}
-		utils.InforF("💡 You can skip/enable some parater to speed up the scan or get more result. See more with the usage %v", color.HiBlueString("osmedeus workflow view -v -f %v", r.RoutineName))
+		utils.InforF("💡 You can skip/enable some parameter to speed up the scan or get more result. See more with the usage %v", color.HiBlueString("osmedeus workflow view -v -f %v", r.RoutineName))
 	}
 }
 


### PR DESCRIPTION
Before, when passing module parameters that differs from the default one, the app wrongly displays that the default value is being used: for example param "enableDnsBruteFocing" in "fast" routine
```
❯ osmedeus.exe -f fast -t example.com -p "enableDnsBruteFocing=true" 
...
[2024-02-15T17:19:19]  INFO 🔘 Toggleable and Skippable Parameters that being use: enablePermutation=false, enableDnsBruteFocing=false,
...
```

Change the order when parsing parameters so that user-supplied parameters values overwrites default values. After:
```
❯ osmedeus.exe -f fast -t example.com -p "enableDnsBruteFocing=true" 
...
[2024-02-15T17:19:19]  INFO 🔘 Toggleable and Skippable Parameters that being use: enablePermutation=false, enableDnsBruteFocing=true,
...
```

__________
When the main module steps takes too long, it could be confusing when users only see "Running prepare scripts for module xxx" for a very long time, so I've added a message when the main steps run.

__________
Fixed 2 typos.