### PR TITLE
[CVE-2024-51735/GHSA-wvv7-wm5v-w2gv] Fix XSS In Markdown Resolver

### DIFF
--- a/core/markdown.go
+++ b/core/markdown.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"path"
+	"text/template"
 
 	"fmt"
 	"os"
@@ -111,6 +112,7 @@ func (r *Runner) ResolveContentSrc(tag string) string {
 		}
 
 		if strings.Contains(tag, "shorten=true") || len(fileContent) > r.Opt.MDCodeBlockLimit {
+			fileContent = template.HTMLEscapeString(fileContent) // sanitize file content to prevent XSS
 			return extendTag(fileContent)
 		}
 


### PR DESCRIPTION
## [CVE-2024-51735/GHSA-wvv7-wm5v-w2gv] Fix XSS In Markdown Resolver

See https://github.com/advisories/GHSA-wvv7-wm5v-w2gv