### PR TITLE
Webhook Notification on all return paths AND extended on_error actions

### DIFF
--- a/internal/executor/artifact_export.go
+++ b/internal/executor/artifact_export.go
@@ -15,21 +15,20 @@ import (
 )
 
 // RegisterArtifacts registers workflow reports and state files as artifacts in the database
-// runID is the integer Run.ID used as a foreign key for artifacts
-func RegisterArtifacts(workflow *core.Workflow, execCtx *core.ExecutionContext, runID int64, logger *zap.Logger) error {
+// and returns the collected artifact file paths. runID is the integer Run.ID used as a
+// foreign key for artifacts. Path collection happens regardless of whether the database
+// is available, so callers can always populate WorkflowResult.Artifacts.
+func RegisterArtifacts(workflow *core.Workflow, execCtx *core.ExecutionContext, runID int64, logger *zap.Logger) ([]string, error) {
 	db := database.GetDB()
-	if db == nil {
-		return nil
-	}
-
 	ctx := context.Background()
 	templateEngine := template.NewEngine()
+	var paths []string
 
 	// Get output path
 	outputPath, ok := execCtx.GetVariable("Output")
 	if !ok {
 		logger.Debug("Output variable not set, skipping artifact registration")
-		return nil
+		return paths, nil
 	}
 	outputStr, _ := outputPath.(string)
 
@@ -43,6 +42,11 @@ func RegisterArtifacts(workflow *core.Workflow, execCtx *core.ExecutionContext, 
 				zap.String("path", report.Path),
 				zap.Error(err),
 			)
+			continue
+		}
+		paths = append(paths, renderedPath)
+
+		if db == nil {
 			continue
 		}
 
@@ -98,6 +102,11 @@ func RegisterArtifacts(workflow *core.Workflow, execCtx *core.ExecutionContext, 
 	// Register state files
 	for _, stateFile := range database.DefaultStateFiles {
 		statePath := filepath.Join(outputStr, stateFile.FileName)
+		paths = append(paths, statePath)
+
+		if db == nil {
+			continue
+		}
 
 		// Check if artifact already exists for this workspace + name
 		var existingArtifact database.Artifact
@@ -171,7 +180,7 @@ func RegisterArtifacts(workflow *core.Workflow, execCtx *core.ExecutionContext, 
 		}
 	}
 
-	return nil
+	return paths, nil
 }
 
 // mapReportTypeToContentType converts workflow report type to database content type

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1135,7 +1135,24 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 		Steps:        make([]*core.StepResult, 0),
 		Exports:      make(map[string]interface{}),
 	}
-
+	
+	// Always emit a workflow_* webhook on every return path (success, failure, cancel, skip, panic).
+    defer func() {
+        if result == nil {
+            return
+        }
+        if result.EndTime.IsZero() {
+            result.EndTime = time.Now()
+        }
+        notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
+            "workflow": module.Name,
+            "kind":     string(core.KindModule),
+            "target":   execCtx.Target,
+            "status":   string(result.Status),
+            "duration": result.EndTime.Sub(result.StartTime).Seconds(),
+        })
+    }()
+	
 	// Record workflow start for metrics
 	metrics.RecordWorkflowStart()
 
@@ -1420,15 +1437,6 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 
 	// Record workflow completion metrics
 	metrics.RecordWorkflowEnd(module.Name, string(core.KindModule), string(result.Status), result.EndTime.Sub(result.StartTime).Seconds())
-
-	// Send webhook notification on completion
-	notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-		"workflow": module.Name,
-		"kind":     string(core.KindModule),
-		"target":   execCtx.Target,
-		"status":   string(result.Status),
-		"duration": result.EndTime.Sub(result.StartTime).Seconds(),
-	})
 
 	// Export state on module completion
 	if stateFile, ok := execCtx.GetVariable("StateFile"); ok {
@@ -1851,6 +1859,23 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 		Exports:      make(map[string]interface{}),
 	}
 
+	// Always emit a workflow_* webhook on every return path (success, failure, cancel, skip, panic).
+    defer func() {
+        if result == nil {
+            return
+        }
+        if result.EndTime.IsZero() {
+            result.EndTime = time.Now()
+        }
+        notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
+            "workflow": module.Name,
+            "kind":     string(core.KindFlow),
+            "target":   execCtx.Target,
+            "status":   string(result.Status),
+            "duration": result.EndTime.Sub(result.StartTime).Seconds(),
+        })
+    }()
+
 	// Record workflow start for metrics
 	metrics.RecordWorkflowStart()
 
@@ -2260,15 +2285,6 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 
 	// Record workflow completion metrics
 	metrics.RecordWorkflowEnd(flow.Name, string(core.KindFlow), string(result.Status), result.EndTime.Sub(result.StartTime).Seconds())
-
-	// Send webhook notification on flow completion
-	notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-		"workflow": flow.Name,
-		"kind":     string(core.KindFlow),
-		"target":   execCtx.Target,
-		"status":   string(result.Status),
-		"duration": result.EndTime.Sub(result.StartTime).Seconds(),
-	})
 
 	// Export state on flow completion
 	if stateFile, ok := execCtx.GetVariable("StateFile"); ok {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1145,12 +1145,15 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 			result.EndTime = time.Now()
 		}
 		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-			"workflow": module.Name,
-			"kind":     string(core.KindModule),
-			"target":   execCtx.Target,
-			"status":   string(result.Status),
-			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
-			"run_uuid": result.RunUUID,
+			"workflow":  module.Name,
+			"kind":      result.WorkflowKind,
+			"target":    execCtx.Target,
+			"status":    string(result.Status),
+			"duration":  result.EndTime.Sub(result.StartTime).Seconds(),
+			"run_uuid":  result.RunUUID,
+			"error":     result.Error.Error(),
+			"artifacts": result.Artifacts,
+			"message":   result.Message,
 		})
 	}()
 
@@ -1869,12 +1872,15 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 			result.EndTime = time.Now()
 		}
 		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-			"workflow": flow.Name,
-			"kind":     string(core.KindFlow),
-			"target":   execCtx.Target,
-			"status":   string(result.Status),
-			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
-			"run_uuid": result.RunUUID,
+			"workflow":  result.WorkflowName,
+			"kind":      result.WorkflowKind,
+			"target":    execCtx.Target,
+			"status":    string(result.Status),
+			"duration":  result.EndTime.Sub(result.StartTime).Seconds(),
+			"run_uuid":  result.RunUUID,
+			"error":     result.Error.Error(),
+			"artifacts": result.Artifacts,
+			"message":   result.Message,
 		})
 	}()
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1135,24 +1135,24 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 		Steps:        make([]*core.StepResult, 0),
 		Exports:      make(map[string]interface{}),
 	}
-	
+
 	// Always emit a workflow_* webhook on every return path (success, failure, cancel, skip, panic).
-    defer func() {
-        if result == nil {
-            return
-        }
-        if result.EndTime.IsZero() {
-            result.EndTime = time.Now()
-        }
-        notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-            "workflow": module.Name,
-            "kind":     string(core.KindModule),
-            "target":   execCtx.Target,
-            "status":   string(result.Status),
-            "duration": result.EndTime.Sub(result.StartTime).Seconds(),
-        })
-    }()
-	
+	defer func() {
+		if result == nil {
+			return
+		}
+		if result.EndTime.IsZero() {
+			result.EndTime = time.Now()
+		}
+		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
+			"workflow": module.Name,
+			"kind":     string(core.KindModule),
+			"target":   execCtx.Target,
+			"status":   string(result.Status),
+			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
+		})
+	}()
+
 	// Record workflow start for metrics
 	metrics.RecordWorkflowStart()
 
@@ -1860,21 +1860,21 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 	}
 
 	// Always emit a workflow_* webhook on every return path (success, failure, cancel, skip, panic).
-    defer func() {
-        if result == nil {
-            return
-        }
-        if result.EndTime.IsZero() {
-            result.EndTime = time.Now()
-        }
-        notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
-            "workflow": module.Name,
-            "kind":     string(core.KindFlow),
-            "target":   execCtx.Target,
-            "status":   string(result.Status),
-            "duration": result.EndTime.Sub(result.StartTime).Seconds(),
-        })
-    }()
+	defer func() {
+		if result == nil {
+			return
+		}
+		if result.EndTime.IsZero() {
+			result.EndTime = time.Now()
+		}
+		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
+			"workflow": flow.Name,
+			"kind":     string(core.KindFlow),
+			"target":   execCtx.Target,
+			"status":   string(result.Status),
+			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
+		})
+	}()
 
 	// Record workflow start for metrics
 	metrics.RecordWorkflowStart()
@@ -3142,6 +3142,14 @@ func (e *Executor) handleModuleAction(action core.Action, execCtx *core.Executio
 		}
 	}
 
+	// Check condition if present
+	if action.Condition != "" {
+		ok, err := e.functionRegistry.EvaluateCondition(action.Condition, execCtx.GetVariables())
+		if err != nil || !ok {
+			return
+		}
+	}
+
 	switch action.Action {
 	case core.ActionLog:
 		rendered, _ := e.templateEngine.Render(action.Message, execCtx.GetVariables())
@@ -3149,6 +3157,36 @@ func (e *Executor) handleModuleAction(action core.Action, execCtx *core.Executio
 
 	case core.ActionExport:
 		execCtx.SetExport(action.Name, action.Value)
+
+	case core.ActionNotify:
+		rendered, _ := e.templateEngine.Render(action.Notify, execCtx.GetVariables())
+		if rendered == "" {
+			rendered = action.Notify
+		}
+		payload := map[string]interface{}{
+			"message":  rendered,
+			"workflow": execCtx.WorkflowName,
+			"run_uuid": execCtx.RunUUID,
+			"target":   execCtx.Target,
+		}
+		if err := notify.SendStructuredEvent("action_notify", "executor", "notification", payload); err != nil {
+			execCtx.Logger.Warn("on_error notify: structured event send failed", zap.Error(err))
+		}
+
+	case core.ActionContinue:
+		if action.Message != "" {
+			rendered, _ := e.templateEngine.Render(action.Message, execCtx.GetVariables())
+			execCtx.Logger.Info("continue: " + rendered)
+		}
+		// Actual continue semantics are decided by shouldContinueOnError().
+
+	case core.ActionAbort:
+		if action.Message != "" {
+			rendered, _ := e.templateEngine.Render(action.Message, execCtx.GetVariables())
+			execCtx.Logger.Warn("abort: " + rendered)
+		}
+		// Mark abort in exports so the caller can honor it.
+		execCtx.SetExport("_abort", "true")
 	}
 }
 
@@ -3184,15 +3222,57 @@ func (e *Executor) processAction(ctx context.Context, action *core.Action, execC
 	case core.ActionExport:
 		execCtx.SetExport(action.Name, action.Value)
 
+	case core.ActionNotify:
+		rendered, _ := e.templateEngine.Render(action.Notify, execCtx.GetVariables())
+		if rendered == "" {
+			rendered = action.Notify
+		}
+		payload := map[string]interface{}{
+			"message":  rendered,
+			"workflow": execCtx.WorkflowName,
+			"run_uuid": execCtx.RunUUID,
+			"target":   execCtx.Target,
+		}
+		if err := notify.SendStructuredEvent("action_notify", "executor", "notification", payload); err != nil {
+			execCtx.Logger.Warn("on_error notify: structured event send failed", zap.Error(err))
+		}
+
+	case core.ActionContinue:
+		if action.Message != "" {
+			rendered, _ := e.templateEngine.Render(action.Message, execCtx.GetVariables())
+			execCtx.Logger.Info("continue: " + rendered)
+		}
+		// Actual continue semantics are decided by shouldContinueOnError().
+
+	case core.ActionAbort:
+		if action.Message != "" {
+			rendered, _ := e.templateEngine.Render(action.Message, execCtx.GetVariables())
+			execCtx.Logger.Warn("abort: " + rendered)
+		}
+		// Mark abort in exports so the caller can honor it.
+		execCtx.SetExport("_abort", "true")
+
 	case core.ActionRun:
-		// Execute embedded step
-		if action.Type == core.StepTypeBash && action.Command != "" {
-			step := &core.Step{
-				Name:    "action-run",
-				Type:    core.StepTypeBash,
-				Command: action.Command,
+		// Execute embedded step (both bash and function forms)
+		switch action.Type {
+		case core.StepTypeBash:
+			if action.Command != "" {
+				step := &core.Step{
+					Name:    "action-run",
+					Type:    core.StepTypeBash,
+					Command: action.Command,
+				}
+				_, _ = e.stepDispatcher.Dispatch(ctx, step, execCtx)
 			}
-			_, _ = e.stepDispatcher.Dispatch(ctx, step, execCtx)
+		case core.StepTypeFunction:
+			if len(action.Functions) > 0 {
+				step := &core.Step{
+					Name:      "action-run",
+					Type:      core.StepTypeFunction,
+					Functions: action.Functions,
+				}
+				_, _ = e.stepDispatcher.Dispatch(ctx, step, execCtx)
+			}
 		}
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1144,6 +1144,10 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 		if result.EndTime.IsZero() {
 			result.EndTime = time.Now()
 		}
+		errMsg := ""
+		if result.Error != nil {
+			errMsg = result.Error.Error()
+		}
 		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
 			"workflow":  module.Name,
 			"kind":      result.WorkflowKind,
@@ -1151,7 +1155,7 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 			"status":    string(result.Status),
 			"duration":  result.EndTime.Sub(result.StartTime).Seconds(),
 			"run_uuid":  result.RunUUID,
-			"error":     result.Error.Error(),
+			"error":     errMsg,
 			"artifacts": result.Artifacts,
 			"message":   result.Message,
 		})
@@ -1871,6 +1875,10 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 		if result.EndTime.IsZero() {
 			result.EndTime = time.Now()
 		}
+		errMsg := ""
+		if result.Error != nil {
+			errMsg = result.Error.Error()
+		}
 		notify.TriggerWebhooks(cfg, "workflow_"+string(result.Status), map[string]interface{}{
 			"workflow":  result.WorkflowName,
 			"kind":      result.WorkflowKind,
@@ -1878,7 +1886,7 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 			"status":    string(result.Status),
 			"duration":  result.EndTime.Sub(result.StartTime).Seconds(),
 			"run_uuid":  result.RunUUID,
-			"error":     result.Error.Error(),
+			"error":     errMsg,
 			"artifacts": result.Artifacts,
 			"message":   result.Message,
 		})

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1150,6 +1150,10 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 			"target":   execCtx.Target,
 			"status":   string(result.Status),
 			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
+			"run_uuid": result.RunUUID,
+			"error":    result.Error,
+			"steps":    result.Steps,
+			"exports":  result.Exports,
 		})
 	}()
 
@@ -1873,6 +1877,10 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 			"target":   execCtx.Target,
 			"status":   string(result.Status),
 			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
+			"run_uuid": result.RunUUID,
+			"error":    result.Error,
+			"steps":    result.Steps,
+			"exports":  result.Exports,
 		})
 	}()
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1466,9 +1466,11 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 
 	// Register artifacts (reports from workflow + state files)
 	if !e.dryRun {
-		if err := RegisterArtifacts(module, execCtx, e.dbRunID, execCtx.Logger); err != nil {
+		paths, err := RegisterArtifacts(module, execCtx, e.dbRunID, execCtx.Logger)
+		if err != nil {
 			execCtx.Logger.Warn("Failed to register artifacts", zap.Error(err))
 		}
+		result.Artifacts = paths
 	}
 
 	// Flush write coordinator at workflow completion
@@ -2322,9 +2324,11 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 
 	// Register artifacts (reports from workflow + state files)
 	if !e.dryRun {
-		if err := RegisterArtifacts(flow, execCtx, e.dbRunID, execCtx.Logger); err != nil {
+		paths, err := RegisterArtifacts(flow, execCtx, e.dbRunID, execCtx.Logger)
+		if err != nil {
 			execCtx.Logger.Warn("Failed to register artifacts", zap.Error(err))
 		}
+		result.Artifacts = paths
 	}
 
 	// Flush write coordinator at workflow completion

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3134,13 +3134,6 @@ func (e *Executor) executeDecisionCondition(ctx context.Context, dc *core.Decisi
 
 // handleModuleAction handles a module action (for flow execution)
 func (e *Executor) handleModuleAction(action core.Action, execCtx *core.ExecutionContext) {
-	// Check condition if present
-	if action.Condition != "" {
-		ok, err := e.functionRegistry.EvaluateCondition(action.Condition, execCtx.GetVariables())
-		if err != nil || !ok {
-			return
-		}
-	}
 
 	// Check condition if present
 	if action.Condition != "" {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1151,9 +1151,6 @@ func (e *Executor) ExecuteModule(ctx context.Context, module *core.Workflow, par
 			"status":   string(result.Status),
 			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
 			"run_uuid": result.RunUUID,
-			"error":    result.Error,
-			"steps":    result.Steps,
-			"exports":  result.Exports,
 		})
 	}()
 
@@ -1878,9 +1875,6 @@ func (e *Executor) ExecuteFlow(ctx context.Context, flow *core.Workflow, params 
 			"status":   string(result.Status),
 			"duration": result.EndTime.Sub(result.StartTime).Seconds(),
 			"run_uuid": result.RunUUID,
-			"error":    result.Error,
-			"steps":    result.Steps,
-			"exports":  result.Exports,
 		})
 	}()
 


### PR DESCRIPTION
# Webhook Notification on all return paths AND extended on_error actions
## Summary

Two improvements to `internal/executor/executor.go` that make workflow event handling more robust and include on_error actions mentioned in the docs.

1. Webhook notifications are now emitted on every exit path of `ExecuteModule` and `ExecuteFlow`, including panics and early-return error paths.
2. New `on_error` action types: `notify`, `continue`, `abort` , `function` type for `run` action in `handleModuleAction` and `processAction`.

## Changes

### 1. Deferred `TriggerWebhooks` in `ExecuteModule` and `ExecuteFlow` 

Before: `notify.TriggerWebhooks(...)` was called at a single point near the end of each function, after completion block. Any early return (dependency failure, cancellation, panic) silently skipped the notification.

After: The call is wrapped in a `defer` registered immediately after the `result` struct is initialized

### 2. New action types: `notify`, `continue`, `abort` 

Both `handleModuleAction` (flow-level) and `processAction` (step-level) now handle three new `ActionType` values defined metioned in the docs:

- `notify`: Sends StructuredEvent to registered receivers
- `continue`: Logs optional message, continue is decided by `shouldContinueOnError()`
- `abort`: Logs optional message, sets export `_abort=true`. This doesn't actually abort itself,  `shouldContinueOnError()` handles this. Real abort semantics would require returning a sentinel error from processAction and threading it through processOnError (Could implement this if wanted)


### 3. `run` action now supports `type: function`

The `run` action only dispatched `type: bash` steps. It now dispatches `type: function` steps, enabling utility functions to be called inline from action handlers.

---

## Affected Files

- `internal/executor/executor.go`

## Testing

```bash
make test-unit
``` passed
```bash
make test-e2e
=== Failed
=== FAIL: test/e2e TestAPI_AllEndpoints/Runs (0.07s)
=== FAIL: test/e2e TestAPI_AllEndpoints (1.90s)
=== FAIL: test/e2e TestCanary_FullSuite (120.97s)
=== FAIL: test/e2e TestCanary_Repo (0.05s)
=== FAIL: test/e2e TestCanary_Domain (0.04s)
=== FAIL: test/e2e TestCanary_CIDR (0.02s)
=== FAIL: test/e2e TestCanary_General (0.02s)
=== FAIL: test/e2e TestCloud_ConfigSet (0.03s)
=== FAIL: test/e2e TestCloud_ConfigShow (0.09s)
=== FAIL: test/e2e TestCloud_ConfigEnvironmentVariables (0.06s)
=== FAIL: test/e2e TestCloud_CreateWithoutConfig (0.03s)
=== FAIL: test/e2e TestCloud_RunWithoutTarget (0.03s)
=== FAIL: test/e2e TestCloud_ProviderValidation (0.03s)
=== FAIL: test/e2e TestCloud_ProviderRegions (0.06s)
=== FAIL: test/e2e TestDistributed_TaskSubmission (32.44s)
=== FAIL: test/e2e TestDistributed_FullWorkflow (48.38s)
=== FAIL: test/e2e TestInstall_WorkflowFromLocalZip (0.03s)
=== FAIL: test/e2e TestInstall_WorkflowFromZipURL (0.03s)
=== FAIL: test/e2e TestInstall_WorkflowFromGitURL (0.04s)
``` 
But these are known "issues".

```bash
make test-e2e-api
=== Failed
=== FAIL: test/e2e TestAPI_AllEndpoints/Runs (0.06s)
=== FAIL: test/e2e TestAPI_AllEndpoints (8.02s)
```
this is because runs.go:362 normalizes priority but tests don't consider it:
```go
// Normalize "medium" to "normal"
if priority == "medium" {
    priority = "normal"
}
```