### PR TITLE
feat: integrate Atlas Cloud provider

### DIFF
--- a/ATLAS_PROVIDER_REVIEW.md
+++ b/ATLAS_PROVIDER_REVIEW.md
@@ -49,7 +49,7 @@
 - Recommended local values:
   - `ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1/chat/completions`
   - `ATLASCLOUD_API_KEY=<local-secret>`
-  - `ATLASCLOUD_MODEL=owl`
+  - `ATLASCLOUD_MODEL=deepseek-ai/DeepSeek-V3-0324`
 
 ## Verification
 
@@ -57,8 +57,7 @@
   - `internal/config/config_test.go`
   - `internal/executor/llm_streaming_test.go`
 
-- Runtime verification completed:
-  - Targeted tests passed for config/provider lookup and LLM executor merge behavior
-  - Real Atlas Cloud chat request succeeded with model `owl`
-  - `deepseek-v3` and `deepseek-v4-flash` returned `400 {"code":400,"msg":"not found"}` for the current account/route
-  - Recommended default Atlas example model is `owl`
+- Completed API-level verification:
+  - Targeted Go tests passed for provider lookup, provider override, env expansion, and streaming paths.
+  - Real Atlas Cloud request succeeded with model `deepseek-ai/DeepSeek-V3-0324`.
+  - Verified response from `POST https://api.atlascloud.ai/v1/chat/completions` returned HTTP 200 and content `atlas-ok`.

--- a/ATLAS_PROVIDER_REVIEW.md
+++ b/ATLAS_PROVIDER_REVIEW.md
@@ -1,0 +1,64 @@
+# Atlas Cloud Provider Review
+
+## Scope
+
+- Added explicit `atlas` provider support on top of the existing OpenAI-compatible LLM path.
+- Enabled environment variable expansion for LLM provider config fields so local secrets can stay out of version control.
+- Updated docs and config examples to show the Atlas Cloud integration path.
+
+## Code Changes
+
+- `internal/config/config.go`
+  - Added `GetProviderByName()` for case-insensitive provider lookup.
+  - Added `ResolveEnvVars()` for `provider`, `base_url`, `auth_token`, `model`, `system_prompt`, and `custom_headers`.
+  - Added Atlas example provider block in the built-in config template.
+
+- `internal/config/settings.go`
+  - Run `cfg.LLM.ResolveEnvVars()` in both normal and strict config parsing.
+
+- `internal/executor/llm_executor.go`
+  - Persist step-level `llm_config.provider`.
+  - Honor explicit provider selection instead of always using rotation.
+  - Return a clear error when a requested provider is not configured.
+
+- `internal/executor/agent_executor.go`
+  - Reused the same explicit provider selection behavior for agent LLM calls.
+
+## Docs And Examples
+
+- `README.md`
+  - Added an Atlas Cloud provider section.
+  - Added the required UTM link:
+    - `https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=osmedeus`
+
+- `docs/api/llm.mdx`
+  - Added Atlas Cloud setup instructions and example env vars.
+
+- `public/presets/osm-settings.example.yaml`
+  - Added commented `atlas` provider example.
+
+- `public/examples/osmedeus-base.example/osm-settings.yaml`
+  - Added commented `atlas` provider example.
+
+- `build/docker/.env.example`
+  - Added Atlas Cloud env variable examples.
+
+## Local Secret Handling
+
+- Real Atlas key should be stored only in a local, ignored file or shell environment.
+- Recommended local values:
+  - `ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1/chat/completions`
+  - `ATLASCLOUD_API_KEY=<local-secret>`
+  - `ATLASCLOUD_MODEL=owl`
+
+## Verification
+
+- Added config/provider coverage in:
+  - `internal/config/config_test.go`
+  - `internal/executor/llm_streaming_test.go`
+
+- Runtime verification completed:
+  - Targeted tests passed for config/provider lookup and LLM executor merge behavior
+  - Real Atlas Cloud chat request succeeded with model `owl`
+  - `deepseek-v3` and `deepseek-v4-flash` returned `400 {"code":400,"msg":"not found"}` for the current account/route
+  - Recommended default Atlas example model is `owl`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ Built for both beginners and experts, it delivers powerful, composable automatio
 
 See [Documentation Page](https://docs.osmedeus.org/) for more details.
 
+## LLM Providers
+
+Osmedeus uses an OpenAI-compatible LLM interface, so MAAS providers such as Atlas Cloud can be integrated by configuring a provider entry with a compatible `base_url`, `auth_token`, and model.
+
+Atlas Cloud setup:
+
+```yaml
+llm_config:
+  llm_providers:
+    - provider: atlas
+      base_url: "${ATLASCLOUD_BASE_URL}"
+      auth_token: "${ATLASCLOUD_API_KEY}"
+      model: "${ATLASCLOUD_MODEL}"
+```
+
+Recommended local environment variables:
+
+```bash
+export ATLASCLOUD_BASE_URL="https://api.atlascloud.ai/v1/chat/completions"
+export ATLASCLOUD_API_KEY="your-atlas-api-key"
+export ATLASCLOUD_MODEL="owl"
+```
+
+Reference:
+- Atlas Cloud docs: [atlascloud.ai/docs](https://www.atlascloud.ai/docs)
+- Atlas Cloud project link: [atlascloud.ai](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=osmedeus)
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Recommended local environment variables:
 ```bash
 export ATLASCLOUD_BASE_URL="https://api.atlascloud.ai/v1/chat/completions"
 export ATLASCLOUD_API_KEY="your-atlas-api-key"
-export ATLASCLOUD_MODEL="owl"
+export ATLASCLOUD_MODEL="deepseek-ai/DeepSeek-V3-0324"
 ```
 
 Reference:

--- a/build/docker/.env.example
+++ b/build/docker/.env.example
@@ -35,6 +35,14 @@ TZ=UTC
 WORKER_REPLICAS=2
 
 # =============================================================================
+# LLM Provider Configuration (Optional)
+# =============================================================================
+# Atlas Cloud OpenAI-compatible endpoint
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1/chat/completions
+ATLASCLOUD_API_KEY=your_atlascloud_api_key_here
+ATLASCLOUD_MODEL=owl
+
+# =============================================================================
 # IMPORTANT NOTES
 # =============================================================================
 # 1. After setting POSTGRES_PASSWORD here, update the same value in:

--- a/build/docker/.env.example
+++ b/build/docker/.env.example
@@ -40,7 +40,7 @@ WORKER_REPLICAS=2
 # Atlas Cloud OpenAI-compatible endpoint
 ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1/chat/completions
 ATLASCLOUD_API_KEY=your_atlascloud_api_key_here
-ATLASCLOUD_MODEL=owl
+ATLASCLOUD_MODEL=deepseek-ai/DeepSeek-V3-0324
 
 # =============================================================================
 # IMPORTANT NOTES

--- a/docs/api/llm.mdx
+++ b/docs/api/llm.mdx
@@ -7,6 +7,35 @@ description: "OpenAI-compatible chat completions and embeddings"
 
 Direct API access to Large Language Model capabilities without requiring workflow execution.
 
+## Atlas Cloud
+
+Atlas Cloud works as a drop-in OpenAI-compatible provider in Osmedeus.
+
+Example `llm_config`:
+
+```yaml
+llm_config:
+  llm_providers:
+    - provider: atlas
+      base_url: "${ATLASCLOUD_BASE_URL}"
+      auth_token: "${ATLASCLOUD_API_KEY}"
+      model: "${ATLASCLOUD_MODEL}"
+```
+
+Recommended local environment variables:
+
+```bash
+export ATLASCLOUD_BASE_URL="https://api.atlascloud.ai/v1/chat/completions"
+export ATLASCLOUD_API_KEY="your-atlas-api-key"
+export ATLASCLOUD_MODEL="owl"
+```
+
+Osmedeus also supports step-level provider selection with `llm_config.provider: atlas`.
+
+Reference:
+- [Atlas Cloud Docs](https://www.atlascloud.ai/docs)
+- [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=osmedeus)
+
 ## Chat Completion
 
 Send a chat completion request to the configured LLM provider.

--- a/docs/api/llm.mdx
+++ b/docs/api/llm.mdx
@@ -27,7 +27,7 @@ Recommended local environment variables:
 ```bash
 export ATLASCLOUD_BASE_URL="https://api.atlascloud.ai/v1/chat/completions"
 export ATLASCLOUD_API_KEY="your-atlas-api-key"
-export ATLASCLOUD_MODEL="owl"
+export ATLASCLOUD_MODEL="deepseek-ai/DeepSeek-V3-0324"
 ```
 
 Osmedeus also supports step-level provider selection with `llm_config.provider: atlas`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -319,6 +319,11 @@ llm_config:
       base_url: "http://localhost:11434/v1/chat/completions"
       auth_token: ""
       model: "gpt-oss:120b-cloud"
+    # Atlas Cloud example (OpenAI-compatible)
+    # - provider: atlas
+    #   base_url: "${ATLASCLOUD_BASE_URL}"
+    #   auth_token: "${ATLASCLOUD_API_KEY}"
+    #   model: "${ATLASCLOUD_MODEL}"
     # Backup provider example (uncomment to enable rotation)
     # - provider: openai
     #   base_url: "https://api.openai.com/v1/chat/completions"
@@ -1055,6 +1060,20 @@ func (l *LLMConfig) GetCurrentProvider() *LLMProvider {
 	return &l.LLMProviders[l.currentIndex]
 }
 
+// GetProviderByName returns the provider with the given name (case-insensitive).
+// Returns nil if no matching provider is configured.
+func (l *LLMConfig) GetProviderByName(name string) *LLMProvider {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for i := range l.LLMProviders {
+		if strings.EqualFold(l.LLMProviders[i].Provider, name) {
+			return &l.LLMProviders[i]
+		}
+	}
+	return nil
+}
+
 // RotateProvider advances to the next LLM provider (thread-safe, wraps around)
 // Returns the new current provider, or nil if no providers are configured
 func (l *LLMConfig) RotateProvider() *LLMProvider {
@@ -1085,6 +1104,18 @@ func (l *LLMConfig) GetCurrentProviderIndex() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.currentIndex
+}
+
+// ResolveEnvVars expands environment variables inside LLM provider fields.
+func (l *LLMConfig) ResolveEnvVars() {
+	for i := range l.LLMProviders {
+		l.LLMProviders[i].Provider = os.ExpandEnv(l.LLMProviders[i].Provider)
+		l.LLMProviders[i].BaseURL = os.ExpandEnv(l.LLMProviders[i].BaseURL)
+		l.LLMProviders[i].AuthToken = os.ExpandEnv(l.LLMProviders[i].AuthToken)
+		l.LLMProviders[i].Model = os.ExpandEnv(l.LLMProviders[i].Model)
+	}
+	l.SystemPrompt = os.ExpandEnv(l.SystemPrompt)
+	l.CustomHeaders = os.ExpandEnv(l.CustomHeaders)
 }
 
 // ResolveServerCredentials adds credentials from environment variables

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerConfig_GetServerURL(t *testing.T) {
@@ -115,4 +116,19 @@ func TestServerConfig_GetEventReceiverURL(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestLLMConfigGetProviderByName(t *testing.T) {
+	llmCfg := LLMConfig{
+		LLMProviders: []LLMProvider{
+			{Provider: "openai", BaseURL: "https://api.openai.com/v1/chat/completions"},
+			{Provider: "atlas", BaseURL: "https://api.atlascloud.ai/v1/chat/completions"},
+		},
+	}
+
+	provider := llmCfg.GetProviderByName("ATLAS")
+	require.NotNil(t, provider)
+	assert.Equal(t, "atlas", provider.Provider)
+	assert.Equal(t, "https://api.atlascloud.ai/v1/chat/completions", provider.BaseURL)
+	assert.Nil(t, llmCfg.GetProviderByName("missing"))
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -10,6 +10,7 @@ func ParseConfig(data []byte) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	cfg.LLM.ResolveEnvVars()
 	return &cfg, nil
 }
 
@@ -19,6 +20,7 @@ func ParseConfigStrict(data []byte) (*Config, error) {
 	if err := yaml.UnmarshalWithOptions(data, &cfg, yaml.Strict()); err != nil {
 		return nil, err
 	}
+	cfg.LLM.ResolveEnvVars()
 	return &cfg, nil
 }
 

--- a/internal/executor/agent_executor.go
+++ b/internal/executor/agent_executor.go
@@ -582,9 +582,13 @@ func (e *AgentExecutor) callLLM(
 	totalAttempts := maxRetries * providerCount
 
 	for attempt := 0; attempt < totalAttempts; attempt++ {
-		provider := e.config.LLM.GetCurrentProvider()
+		provider := e.getProviderForRequest(llmConfig)
 		if provider == nil {
-			lastErr = fmt.Errorf("no LLM providers available")
+			if llmConfig.Provider != "" {
+				lastErr = fmt.Errorf("LLM provider %q not configured", llmConfig.Provider)
+			} else {
+				lastErr = fmt.Errorf("no LLM providers available")
+			}
 			break
 		}
 
@@ -637,6 +641,13 @@ func (e *AgentExecutor) sendChatRequest(
 ) (*ChatCompletionResponse, error) {
 	llmExec := &LLMExecutor{config: e.config}
 	return llmExec.sendChatRequest(ctx, provider, request, llmConfig)
+}
+
+func (e *AgentExecutor) getProviderForRequest(llmConfig *MergedLLMConfig) *config.LLMProvider {
+	if llmConfig != nil && llmConfig.Provider != "" {
+		return e.config.LLM.GetProviderByName(llmConfig.Provider)
+	}
+	return e.config.LLM.GetCurrentProvider()
 }
 
 // executeToolCalls executes tool calls from the LLM response, with tracing hooks (Group 7)

--- a/internal/executor/llm_executor.go
+++ b/internal/executor/llm_executor.go
@@ -65,6 +65,7 @@ func (e *LLMExecutor) CanHandle(stepType core.StepType) bool {
 
 // MergedLLMConfig holds the final merged configuration
 type MergedLLMConfig struct {
+	Provider       string
 	Model          string
 	MaxTokens      int
 	Temperature    float64
@@ -288,9 +289,13 @@ func (e *LLMExecutor) executeChatCompletion(
 	totalAttempts := maxRetries * providerCount
 
 	for attempt := 0; attempt < totalAttempts; attempt++ {
-		provider := e.config.LLM.GetCurrentProvider()
+		provider := e.getProviderForRequest(llmConfig)
 		if provider == nil {
-			lastErr = fmt.Errorf("no LLM providers available")
+			if llmConfig.Provider != "" {
+				lastErr = fmt.Errorf("LLM provider %q not configured", llmConfig.Provider)
+			} else {
+				lastErr = fmt.Errorf("no LLM providers available")
+			}
 			break
 		}
 
@@ -412,9 +417,13 @@ func (e *LLMExecutor) executeEmbedding(
 	totalAttempts := maxRetries * providerCount
 
 	for attempt := 0; attempt < totalAttempts; attempt++ {
-		provider := e.config.LLM.GetCurrentProvider()
+		provider := e.getProviderForRequest(llmConfig)
 		if provider == nil {
-			lastErr = fmt.Errorf("no LLM providers available")
+			if llmConfig.Provider != "" {
+				lastErr = fmt.Errorf("LLM provider %q not configured", llmConfig.Provider)
+			} else {
+				lastErr = fmt.Errorf("no LLM providers available")
+			}
 			break
 		}
 
@@ -1039,6 +1048,10 @@ func (e *LLMExecutor) getMergedConfig(step *core.Step) *MergedLLMConfig {
 	if step.LLMConfig != nil {
 		cfg := step.LLMConfig
 
+		if cfg.Provider != "" {
+			merged.Provider = cfg.Provider
+		}
+
 		if cfg.Model != "" {
 			merged.Model = cfg.Model
 		}
@@ -1101,6 +1114,13 @@ func (e *LLMExecutor) getMergedConfig(step *core.Step) *MergedLLMConfig {
 	}
 
 	return merged
+}
+
+func (e *LLMExecutor) getProviderForRequest(llmConfig *MergedLLMConfig) *config.LLMProvider {
+	if llmConfig != nil && llmConfig.Provider != "" {
+		return e.config.LLM.GetProviderByName(llmConfig.Provider)
+	}
+	return e.config.LLM.GetCurrentProvider()
 }
 
 // isProviderError checks if error indicates provider-level failure

--- a/internal/executor/llm_streaming_test.go
+++ b/internal/executor/llm_streaming_test.go
@@ -214,6 +214,44 @@ func TestStreamingTokenCallback(t *testing.T) {
 	assert.Equal(t, []string{"token1", "token2", "token3", "\n"}, tokens)
 }
 
+func TestMergedConfigProviderOverrideAndEnvExpansion(t *testing.T) {
+	t.Setenv("ATLASCLOUD_BASE_URL", "https://api.atlascloud.ai/v1/chat/completions")
+	t.Setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
+	t.Setenv("ATLASCLOUD_MODEL", "owl")
+
+	cfg, err := config.LoadFromBytes([]byte(`
+llm_config:
+  llm_providers:
+    - provider: atlas
+      base_url: "${ATLASCLOUD_BASE_URL}"
+      auth_token: "${ATLASCLOUD_API_KEY}"
+      model: "${ATLASCLOUD_MODEL}"
+    - provider: openai
+      base_url: "https://api.openai.com/v1/chat/completions"
+      auth_token: "sk-test"
+      model: "gpt-4o-mini"
+`))
+	require.NoError(t, err)
+
+	executor := &LLMExecutor{config: cfg}
+	step := &core.Step{
+		Type: core.StepTypeLLM,
+		LLMConfig: &core.LLMStepConfig{
+			Provider: "atlas",
+		},
+	}
+
+	merged := executor.getMergedConfig(step)
+	assert.Equal(t, "atlas", merged.Provider)
+
+	selectedProvider := executor.getProviderForRequest(merged)
+	require.NotNil(t, selectedProvider)
+	assert.Equal(t, "atlas", selectedProvider.Provider)
+	assert.Equal(t, "https://api.atlascloud.ai/v1/chat/completions", selectedProvider.BaseURL)
+	assert.Equal(t, "test-atlas-key", selectedProvider.AuthToken)
+	assert.Equal(t, "owl", selectedProvider.Model)
+}
+
 func TestStreamingToolCallAccumulation(t *testing.T) {
 	// Simulate streaming tool calls: name arrives in one chunk, arguments split across chunks
 	server := newStreamingMockServer(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/executor/llm_streaming_test.go
+++ b/internal/executor/llm_streaming_test.go
@@ -217,7 +217,7 @@ func TestStreamingTokenCallback(t *testing.T) {
 func TestMergedConfigProviderOverrideAndEnvExpansion(t *testing.T) {
 	t.Setenv("ATLASCLOUD_BASE_URL", "https://api.atlascloud.ai/v1/chat/completions")
 	t.Setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
-	t.Setenv("ATLASCLOUD_MODEL", "owl")
+	t.Setenv("ATLASCLOUD_MODEL", "deepseek-ai/DeepSeek-V3-0324")
 
 	cfg, err := config.LoadFromBytes([]byte(`
 llm_config:
@@ -249,7 +249,7 @@ llm_config:
 	assert.Equal(t, "atlas", selectedProvider.Provider)
 	assert.Equal(t, "https://api.atlascloud.ai/v1/chat/completions", selectedProvider.BaseURL)
 	assert.Equal(t, "test-atlas-key", selectedProvider.AuthToken)
-	assert.Equal(t, "owl", selectedProvider.Model)
+	assert.Equal(t, "deepseek-ai/DeepSeek-V3-0324", selectedProvider.Model)
 }
 
 func TestStreamingToolCallAccumulation(t *testing.T) {

--- a/public/examples/osmedeus-base.example/osm-settings.yaml
+++ b/public/examples/osmedeus-base.example/osm-settings.yaml
@@ -262,6 +262,11 @@ llm_config:
       base_url: "http://localhost:11434/v1/chat/completions"
       auth_token: ""
       model: "gpt-oss:120b-cloud"
+    # Atlas Cloud example (OpenAI-compatible)
+    # - provider: atlas
+    #   base_url: "${ATLASCLOUD_BASE_URL}"
+    #   auth_token: "${ATLASCLOUD_API_KEY}"
+    #   model: "${ATLASCLOUD_MODEL}"
     # Backup provider example (uncomment to enable rotation)
     # - provider: openai
     #   base_url: "https://api.openai.com/v1/chat/completions"

--- a/public/presets/osm-settings.example.yaml
+++ b/public/presets/osm-settings.example.yaml
@@ -423,6 +423,11 @@ llm_config:
       base_url: "http://localhost:11434/v1/chat/completions"
       auth_token: ""
       model: "gpt-oss:120b-cloud"
+    # Atlas Cloud example (OpenAI-compatible)
+    # - provider: atlas
+    #   base_url: "${ATLASCLOUD_BASE_URL}"
+    #   auth_token: "${ATLASCLOUD_API_KEY}"
+    #   model: "${ATLASCLOUD_MODEL}"
     # Backup provider example (uncomment to enable rotation)
     # - provider: openai
     #   base_url: "https://api.openai.com/v1/chat/completions"


### PR DESCRIPTION
Added Atlas Cloud provider, ensured OpenAI-compatible API integration works with model deepseek-ai/DeepSeek-V3-0324. Updated documentation and config examples.