### PR TITLE
fix(installer): validate symlink targets stay within extraction directory

### DIFF
--- a/internal/installer/archive.go
+++ b/internal/installer/archive.go
@@ -133,6 +133,14 @@ func extractTarEntry(header *tar.Header, tr *tar.Reader, dest string) error {
 		_ = outFile.Close()
 
 	case tar.TypeSymlink:
+		// Validate the symlink target stays within dest to prevent symlink traversal
+		linkTarget := header.Linkname
+		if !filepath.IsAbs(linkTarget) {
+			linkTarget = filepath.Join(filepath.Dir(path), linkTarget)
+		}
+		if !strings.HasPrefix(filepath.Clean(linkTarget)+string(os.PathSeparator), filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("symlink target %q would escape destination directory", header.Linkname)
+		}
 		// Create parent directory
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err


### PR DESCRIPTION
extractTarEntry validates regular file and directory paths against the destination root, but the tar.TypeSymlink case creates symlinks without checking where the link target points. A crafted archive can plant a symlink to a path outside dest and then write through it in a following entry, escaping the extraction directory. Added a filepath.Clean prefix check on the resolved link target before os.Symlink is called.